### PR TITLE
feat: remove block_number index for transactions

### DIFF
--- a/priv/repo/migrations/20220307032631_remove_block_number_index.exs
+++ b/priv/repo/migrations/20220307032631_remove_block_number_index.exs
@@ -1,0 +1,7 @@
+defmodule GodwokenExplorer.Repo.Migrations.RemoveBlockNumberIndex do
+  use Ecto.Migration
+
+  def change do
+    drop index(:transactions, :block_number)
+  end
+end


### PR DESCRIPTION
sort use block_number index is slow